### PR TITLE
Symfony3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       env: SYMFONY_VERSION=2.5.*
     - php: 5.5
       env: SYMFONY_VERSION=dev-master
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*
 
 
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('name')->defaultValue('webmaster')->cannotBeEmpty()->end()
                     ->end()
             ->end()
-            ->booleanNode('fake_request')->defaultFalse()->cannotBeEmpty()->end()
+            ->booleanNode('fake_request')->defaultFalse()->end()
             ->scalarNode('request_provider_service')->end()
             ->scalarNode('error_type')->defaultValue('exception')->validate()
                 ->ifNotInArray(array('exception', 'error', 'warning', 'notice', 'none'))

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,14 +6,14 @@ services:
   happyr.mailer:
     class: %happyr_mailer.user_class%
     arguments:
-      - @mailer
-      - @templating
-      - @service_container
-      - @happyr.mailer.provider.request
-      - name: %happyr_mailer.from.name%
-        email: %happyr_mailer.from.email%
-        errorType: %happyr_mailer.error_type%
-        fakeRequest: %happyr_mailer.fake_request%
+      - "@mailer"
+      - "@templating"
+      - "@service_container"
+      - "@happyr.mailer.provider.request"
+      - name: "%happyr_mailer.from.name%"
+        email: "%happyr_mailer.from.email%"
+        errorType: "%happyr_mailer.error_type%"
+        fakeRequest: "%happyr_mailer.fake_request%"
 
   happyr.mailer.provider.request:
-    class: %happyr.mailer.provider.request.class%
+    class: "%happyr.mailer.provider.request.class%"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "twig/twig": "*",
         "swiftmailer/swiftmailer": "*",
-        "symfony/yaml": "2.*"
+        "symfony/yaml": "2.*|3.*"
     },
     "require-dev": {
         "mockery/mockery": "*"

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "twig/twig": "*",
-        "swiftmailer/swiftmailer": "*",
-        "symfony/yaml": "2.*|3.*"
+        "twig/twig": "^1.24",
+        "swiftmailer/swiftmailer": "^5.4",
+        "symfony/yaml": "^2.3|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "*"


### PR DESCRIPTION
Hi Tobias,

I've forked your bundle and updated some code for symfony3 compatibility. Currently only tested on symfony 3.0.4 but probably backwards compatible. I love the simple design and the fast and easy way of sending emails but do not want to go back on older versions of symfony. As I see is there just a twig version dependency problem and some fixes with the parameter passing (using "").

So hope my solution is helpfull.

Regards

Konstantin
